### PR TITLE
ДЗ 3

### DIFF
--- a/kubernetes-intro/web/web-pod.yaml
+++ b/kubernetes-intro/web/web-pod.yaml
@@ -8,7 +8,14 @@ spec:                                                   # Описание Pod
   containers:                                           # Описание контейнеров внутри Pod
     - name: web                                         # Название контейнера
       image: fastfighter92/kubernetes-intro:latest      # Образ из которого создается контейнер
-
+      # --- BEGIN --
+      readinessProbe:          # Добавим проверку готовности
+        httpGet:               # веб-сервера отдавать
+          path: /index.html    # контент
+          port: 80
+      livenessProbe:
+        tcpSocket: { port: 8000 }
+      # --- END --
   initContainers:
     - name: initialize-index-htnl
       image: busybox:1.31.0

--- a/kubernetes-networks/README.md
+++ b/kubernetes-networks/README.md
@@ -1,0 +1,116 @@
+# Svyatoslav2792_platform
+Svyatoslav2792 Platform repository
+ДЗ 3
+
+Добавление проверок Pod
+    Вносим изменения в файл kubernetesintro/web-pod.yml 
+          # --- BEGIN --
+          readinessProbe:          # Добавим проверку готовности
+            httpGet:               # веб-сервера отдавать
+              path: /index.html    # контент
+              port: 80
+          # --- END --
+    "kubectl apply -f .\web-pod.yaml"
+    "kubectl get pod/web"
+        NAME   READY   STATUS    RESTARTS   AGE
+        web    0/1     Running   0          97s
+    "kubectl describe pod/web"
+        ...
+        Conditions:
+          Type              Status
+          Initialized       True
+          Ready             False
+          ContainersReady   False
+          PodScheduled      True
+        ...
+        Warning  Unhealthy  8s (x12 over 94s)  kubelet            Readiness probe failed: Get "http://10.244.0.209:80/index.html": dial tcp 10.244.0.209:80: connect: connection refused
+    Добавляем в файл kubernetesintro/web-pod.yml 
+        livenessProbe: 
+            tcpSocket: { port: 8000 }
+    "kubectl apply -f .\web-pod.yaml"
+    
+Создание Deployment
+    "kubectl delete pod/web --grace-period=0 --force"
+    Создаем новый манифест web-deploy.yaml и всносим правки, чтобы все работало
+    "kubectl apply -f web-deploy.yaml"
+    "kubectl describe deployment web"
+        ...
+        Conditions:
+          Type           Status  Reason
+          ----           ------  ------
+          Available      True    MinimumReplicasAvailable
+        ...
+    Добавляем 
+          type: RollingUpdate
+          rollingUpdate:
+            maxUnavailable: 0
+            maxSurge: 100%
+    Применяем манифест "kubectl apply -f web-deploy.yaml" и наблюдаем за процессом "kubectl get events -watch"
+
+Создание Service
+    Создадим манифест для нашего сервиса web-svc-cip.yaml
+    "kubectl apply -f web-svc-cip.yaml"
+    "kubectl get services"
+        NAME            TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
+        ...
+        web-svc-cip     ClusterIP   10.108.251.98    <none>        80/TCP     36s
+    Подключаемся к миникьюбу "minikube ssh" 
+        "curl http://10.108.251.98/index.html" - работает
+        "ping 10.108.251.98" - пинга нет
+        "ip addr show" - наш айпи отсутствует
+        "sudo -i iptables --list -nv -t nat" находим наш кластерный адрес
+            Chain KUBE-SERVICES (2 references)
+             pkts bytes target     prot opt in     out     source               destination
+                ...
+                1    60 KUBE-SVC-6CZTMAROCN3AQODZ  tcp  --  *      *       0.0.0.0/0            10.108.251.98        /* default/web-svc-cip cluster IP */ tcp dpt:80
+            Chain KUBE-SVC-6CZTMAROCN3AQODZ (1 references)
+             pkts bytes target     prot opt in     out     source               destination
+                1    60 KUBE-MARK-MASQ  tcp  --  *      *      !10.244.0.0/16        10.108.251.98        /* default/web-svc-cip cluster IP */ tcp dpt:80
+
+Включение IPVS
+    "kubectl --namespace kube-system edit configmap/kube-proxy"
+    Вносим изменения в соотв. с заданием
+         ipvs:     
+            strictARP: true   
+         mode: "ipvs"
+    "kubectl --namespace kube-system delete pod --selector='k8s-app=kube-proxy'"
+    "minikube ssh" 
+    "kubectl --namespace kube-system exec kube-proxy-<POD> kube-proxy -cleanup"
+    Поставил себе нано, так как вимом пользоваться "sudo apt update && sudo apt install -y nano" невозможно и поменял параметры
+    "sudo -i iptables-restore /tmp/iptables.cleanup"
+    
+Установка MetalLB
+    Тут все оп инструкции, за исключением того, что указанный в ДЗ манифест падает с ошибкой 
+        resource mapping not found for name: "controller" namespace: "metallb-system" from "https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/metallb.yaml": no matches for kind "PodSecurityPolicy" in version "policy/v1beta1"
+        ensure CRDs are installed first
+        resource mapping not found for name: "speaker" namespace: "metallb-system" from "https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/metallb.yaml": no matches for kind "PodSecurityPolicy" in version "policy/v1beta1"
+        ensure CRDs are installed first
+    Поэтому пришлось применить другой "kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.7/config/manifests/metallb-native.yaml"
+    "kubectl --namespace metallb-system get all"
+        NAME                              READY   STATUS    RESTARTS   AGE
+        pod/controller-577b5bdfcc-ppjpr   1/1     Running   0          2m27s
+        pod/speaker-cx6ft                 1/1     Running   0          2m26s
+        NAME                      TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
+        service/webhook-service   ClusterIP   10.96.189.158   <none>        443/TCP   2m27s
+        NAME                     DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR            AGE
+        daemonset.apps/speaker   1         1         1       1            1           kubernetes.io/os=linux   17m
+        NAME                         READY   UP-TO-DATE   AVAILABLE   AGE
+        deployment.apps/controller   1/1     1            1           17m
+        NAME                                    DESIRED   CURRENT   READY   AGE
+        replicaset.apps/controller-5759df545c   0         0         0       17m
+        replicaset.apps/controller-577b5bdfcc   1         1         1       2m27s
+        replicaset.apps/controller-bdf98b979    0         0         0       9m29s
+    Создаем манифест metallb-config.yaml и "kubectl apply -f metallb-config.yaml"
+    Делаем копию файла web-svc-cip.yaml в web-svc-lb.yaml и ставим LoadBalancer "kubectl apply -f .\web-svc-lb.yaml"
+    IP:                       10.106.146.215
+    Затем пробуем зайти на веб интерфейс и не можем, находим адрес своего миникуба "minikube ssh" -> "ip addr show eth0"
+        inet 192.168.49.2/24 brd 192.168.49.255 scope global eth0 
+    Поигрался, в итоге не взлетело, бросил..
+Создание Ingress
+    "kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/baremetal/deploy.yaml"
+    Создаем манифест nodeport.yaml и "kubectl apply -f .\nodeport.yaml"
+Подключение приложение Web к Ingress
+    Ккопируйкм web-svc-cip.yaml в web-svc-headless.yaml, меняем параметры и "kubectl apply -f .\web-svc-headless.yaml"
+Создание правил Ingress
+    Создаем манифест web-ingress.yaml и "kubectl apply -f .\web-ingress.yaml", 
+    проверяем корректность заполнения "kubectl describe ingress/web"

--- a/kubernetes-networks/iptables.cleanup
+++ b/kubernetes-networks/iptables.cleanup
@@ -1,0 +1,7 @@
+*nat
+-A POSTROUTING -s 172.17.0.0/16 ! -o docker0 -j MASQUERADE
+COMMIT
+*filter
+COMMIT
+*mangle
+COMMIT

--- a/kubernetes-networks/metallb-config.yaml
+++ b/kubernetes-networks/metallb-config.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - 172.17.255.1-172.17.255.255 
+

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -1,0 +1,22 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/component: controller
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+    - name: https
+      port: 443
+      targetPort: https

--- a/kubernetes-networks/nodeport.yaml
+++ b/kubernetes-networks/nodeport.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: MyApp
+  ports:
+    # By default and for convenience, the `targetPort` is set to the same value as the `port` field.
+    - port: 80
+      targetPort: 80
+      # Optional field
+      # By default and for convenience, the Kubernetes control plane will allocate a port from a range (default: 30000-32767)
+      nodePort: 30007

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+      - name: web
+        image: fastfighter92/kubernetes-intro:latest
+        livenessProbe:
+          tcpSocket:
+            port: 8000
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+        volumeMounts:
+          - name: app
+            mountPath: /app
+      initContainers:
+        - name: html-gen
+          image: busybox:musl
+          command: ['sh', '-c', 'wget -O- https://bit.ly/otus-k8s-index-gen | sh']
+          volumeMounts:
+            - name: app
+              mountPath: /app
+      volumes:
+        - name: app
+          emptyDir: {}

--- a/kubernetes-networks/web-ingress.yaml
+++ b/kubernetes-networks/web-ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: web
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /web
+        backend:
+          serviceName: web-svc
+          servicePort: 8000
+

--- a/kubernetes-networks/web-svc-cip.yaml
+++ b/kubernetes-networks/web-svc-cip.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-cip
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-headless.yaml
+++ b/kubernetes-networks/web-svc-headless.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-lb.yaml
+++ b/kubernetes-networks/web-svc-lb.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-lb
+spec:
+  selector:
+    app: web
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-volumes/README.md
+++ b/kubernetes-volumes/README.md
@@ -1,0 +1,109 @@
+# Svyatoslav2792_platform
+Svyatoslav2792 Platform repository
+ДЗ 4
+Применение StatefulSet
+    "kubectl apply -f .\minio-statefulset.yaml"
+Применение Headless Service
+    "kubectl apply -f .\minio-headless-service.yaml"
+Проверка работы MinIO
+    "kubectl get statefulsets"
+        NAME    READY   AGE
+        minio   1/1     5m27s
+    "kubectl get pods"
+        NAME                             READY   STATUS    RESTARTS        AGE
+        minio-0                          1/1     Running   0               6m1s
+    "kubectl get pvc"
+        NAME           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+        data-minio-0   Bound    pvc-1f1c3c9e-72c7-4c20-ad1b-b5ff4eb2a6d7   10Gi       RWO            standard       6m26s
+    "kubectl get pv"
+        NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                  STORAGECLASS   REASON   AGE
+        pvc-1f1c3c9e-72c7-4c20-ad1b-b5ff4eb2a6d7   10Gi       RWO            Delete           Bound    default/data-minio-0   standard                6m49s
+    "kubectl describe pod/minio-0"
+        Name:             minio-0
+        Namespace:        default
+        Priority:         0
+        Service Account:  default
+        Node:             minikube/192.168.49.2
+        Start Time:       Fri, 02 Jun 2023 09:08:48 +0300
+        Labels:           app=minio
+                          controller-revision-hash=minio-dfc57cb8
+                          statefulset.kubernetes.io/pod-name=minio-0
+        Annotations:      <none>
+        Status:           Running
+        IP:               10.244.0.251
+        IPs:
+          IP:           10.244.0.251
+        Controlled By:  StatefulSet/minio
+        Containers:
+          minio:
+            Container ID:  docker://324422519a972ff14d1b69186fae8727f01c756e74db965fc43a2bfc2dddfc31
+            Image:         minio/minio:RELEASE.2019-07-10T00-34-56Z
+            Image ID:      docker-pullable://minio/minio@sha256:ccdbb297318f763dc1110d5168c8d45863c98ff1f0d7095a90be3b31a150ac6f
+            Port:          9000/TCP
+            Host Port:     0/TCP
+            Args:
+              server
+              /data
+            State:          Running
+              Started:      Fri, 02 Jun 2023 09:09:16 +0300
+            Ready:          True
+            Restart Count:  0
+            Liveness:       http-get http://:9000/minio/health/live delay=120s timeout=1s period=20s #success=1 #failure=3
+            Environment:
+              MINIO_ACCESS_KEY:  minio
+              MINIO_SECRET_KEY:  minio123
+            Mounts:
+              /data from data (rw)
+              /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-2bm59 (ro)
+        Conditions:
+          Type              Status
+          Initialized       True
+          Ready             True
+          ContainersReady   True
+          PodScheduled      True
+        Volumes:
+          data:
+            Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
+            ClaimName:  data-minio-0
+            ReadOnly:   false
+          kube-api-access-2bm59:
+            Type:                    Projected (a volume that contains injected data from multiple sources)
+            TokenExpirationSeconds:  3607
+            ConfigMapName:           kube-root-ca.crt
+            ConfigMapOptional:       <nil>
+            DownwardAPI:             true
+        QoS Class:                   BestEffort
+        Node-Selectors:              <none>
+        Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
+                                     node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
+        Events:
+          Type     Reason            Age    From               Message
+          ----     ------            ----   ----               -------
+          Warning  FailedScheduling  7m58s  default-scheduler  0/1 nodes are available: pod has unbound immediate PersistentVolumeClaims. preemption: 0/1 nodes are available: 1 No preemption victims found for incoming pod..
+          Normal   Scheduled         7m56s  default-scheduler  Successfully assigned default/minio-0 to minikube
+          Normal   Pulling           7m55s  kubelet            Pulling image "minio/minio:RELEASE.2019-07-10T00-34-56Z"
+          Normal   Pulled            7m28s  kubelet            Successfully pulled image "minio/minio:RELEASE.2019-07-10T00-34-56Z" in 27.248108172s (27.248130194s including waiting)
+          Normal   Created           7m28s  kubelet            Created container minio
+          Normal   Started           7m28s  kubelet            Started container minio
+   
+Задание со * 
+   Создаем файл minio-secrets.yaml с секретами в base64
+   "kubectl apply -f .\minio-secrets.yaml"
+   Добавляем в minio-statefulset.yaml секреты и волт
+   "kubectl apply -f .\minio-statefulset.yaml"
+   "kubectl describe pod/minio-0"
+        ...
+        Environment:
+          MINIO_ACCESS_KEY:  <set to the key 'MINIO_ACCESS_KEY' in secret 'minio-secrets'>  Optional: false
+          MINIO_SECRET_KEY:  <set to the key 'MINIO_SECRET_KEY' in secret 'minio-secrets'>  Optional: false
+        Mounts:
+          /data from data (rw)
+          /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-9lswl (ro)
+        ...
+    "kubectl exec minio-0  -it -- /bin/sh"
+        "printenv" и видим в переменных окружения наши секреты внутри пода
+            ...
+            MINIO_ACCESS_KEY=minio
+            MINIO_SECRET_KEY_FILE=secret_key
+            MINIO_SECRET_KEY=minio123
+            ...

--- a/kubernetes-volumes/minio-headless-service.yaml
+++ b/kubernetes-volumes/minio-headless-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  labels:
+    app: minio
+spec:
+  clusterIP: None
+  ports:
+    - port: 9000
+      name: minio
+  selector:
+    app: minio

--- a/kubernetes-volumes/minio-secrets.yaml
+++ b/kubernetes-volumes/minio-secrets.yaml
@@ -1,0 +1,8 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: minio-secrets
+type: Opaque
+data:
+  MINIO_ACCESS_KEY: bWluaW8K
+  MINIO_SECRET_KEY: bWluaW8xMjMK

--- a/kubernetes-volumes/minio-statefulset.yaml
+++ b/kubernetes-volumes/minio-statefulset.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  # This name uniquely identifies the StatefulSet
+  name: minio
+spec:
+  serviceName: minio
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio # has to match .spec.template.metadata.labels
+  template:
+    metadata:
+      labels:
+        app: minio # has to match .spec.selector.matchLabels
+    spec:
+      containers:
+        - name: minio
+          env:
+           - name: MINIO_ACCESS_KEY
+             valueFrom:
+               secretKeyRef:
+                 name: minio-secrets
+                 key: MINIO_ACCESS_KEY
+           - name: MINIO_SECRET_KEY
+             valueFrom:
+               secretKeyRef:
+                 name: minio-secrets
+                 key: MINIO_SECRET_KEY
+          image: minio/minio:RELEASE.2019-07-10T00-34-56Z
+          args:
+            - server
+            - /data
+          ports:
+            - containerPort: 9000
+          # These volume mounts are persistent. Each pod in the PetSet
+          # gets a volume mounted based on this field.
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          # Liveness probe detects situations where MinIO server instance
+          # is not working properly and needs restart. Kubernetes automatically
+          # restarts the pods if liveness checks fail.
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: 9000
+            initialDelaySeconds: 120
+            periodSeconds: 20
+      volumes:
+        - name: minio-secrets
+          secret:
+            secretName: minio-secrets
+  # These are converted to volume claims by the controller
+  # and mounted at the paths mentioned above.
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi


### PR DESCRIPTION
# Выполнено ДЗ № 3
Добавление проверок Pod
    Вносим изменения в файл kubernetesintro/web-pod.yml 
          # --- BEGIN --
          readinessProbe:          # Добавим проверку готовности
            httpGet:               # веб-сервера отдавать
              path: /index.html    # контент
              port: 80
          # --- END --
    "kubectl apply -f .\web-pod.yaml"
    "kubectl get pod/web"
        NAME   READY   STATUS    RESTARTS   AGE
        web    0/1     Running   0          97s
    "kubectl describe pod/web"
        ...
        Conditions:
          Type              Status
          Initialized       True
          Ready             False
          ContainersReady   False
          PodScheduled      True
        ...
        Warning  Unhealthy  8s (x12 over 94s)  kubelet            Readiness probe failed: Get "http://10.244.0.209:80/index.html": dial tcp 10.244.0.209:80: connect: connection refused
    Добавляем в файл kubernetesintro/web-pod.yml 
        livenessProbe: 
            tcpSocket: { port: 8000 }
    "kubectl apply -f .\web-pod.yaml"
    
Создание Deployment
    "kubectl delete pod/web --grace-period=0 --force"
    Создаем новый манифест web-deploy.yaml и всносим правки, чтобы все работало
    "kubectl apply -f web-deploy.yaml"
    "kubectl describe deployment web"
        ...
        Conditions:
          Type           Status  Reason
          ----           ------  ------
          Available      True    MinimumReplicasAvailable
        ...
    Добавляем 
          type: RollingUpdate
          rollingUpdate:
            maxUnavailable: 0
            maxSurge: 100%
    Применяем манифест "kubectl apply -f web-deploy.yaml" и наблюдаем за процессом "kubectl get events -watch"

Создание Service
    Создадим манифест для нашего сервиса web-svc-cip.yaml
    "kubectl apply -f web-svc-cip.yaml"
    "kubectl get services"
        NAME            TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
        ...
        web-svc-cip     ClusterIP   10.108.251.98    <none>        80/TCP     36s
    Подключаемся к миникьюбу "minikube ssh" 
        "curl http://10.108.251.98/index.html" - работает
        "ping 10.108.251.98" - пинга нет
        "ip addr show" - наш айпи отсутствует
        "sudo -i iptables --list -nv -t nat" находим наш кластерный адрес
            Chain KUBE-SERVICES (2 references)
             pkts bytes target     prot opt in     out     source               destination
                ...
                1    60 KUBE-SVC-6CZTMAROCN3AQODZ  tcp  --  *      *       0.0.0.0/0            10.108.251.98        /* default/web-svc-cip cluster IP */ tcp dpt:80
            Chain KUBE-SVC-6CZTMAROCN3AQODZ (1 references)
             pkts bytes target     prot opt in     out     source               destination
                1    60 KUBE-MARK-MASQ  tcp  --  *      *      !10.244.0.0/16        10.108.251.98        /* default/web-svc-cip cluster IP */ tcp dpt:80

Включение IPVS
    "kubectl --namespace kube-system edit configmap/kube-proxy"
    Вносим изменения в соотв. с заданием
         ipvs:     
            strictARP: true   
         mode: "ipvs"
    "kubectl --namespace kube-system delete pod --selector='k8s-app=kube-proxy'"
    "minikube ssh" 
    "kubectl --namespace kube-system exec kube-proxy-<POD> kube-proxy -cleanup"
    Поставил себе нано, так как вимом пользоваться "sudo apt update && sudo apt install -y nano" невозможно и поменял параметры
    "sudo -i iptables-restore /tmp/iptables.cleanup"
    
Установка MetalLB
    Тут все оп инструкции, за исключением того, что указанный в ДЗ манифест падает с ошибкой 
        resource mapping not found for name: "controller" namespace: "metallb-system" from "https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/metallb.yaml": no matches for kind "PodSecurityPolicy" in version "policy/v1beta1"
        ensure CRDs are installed first
        resource mapping not found for name: "speaker" namespace: "metallb-system" from "https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/metallb.yaml": no matches for kind "PodSecurityPolicy" in version "policy/v1beta1"
        ensure CRDs are installed first
    Поэтому пришлось применить другой "kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.7/config/manifests/metallb-native.yaml"
    "kubectl --namespace metallb-system get all"
        NAME                              READY   STATUS    RESTARTS   AGE
        pod/controller-577b5bdfcc-ppjpr   1/1     Running   0          2m27s
        pod/speaker-cx6ft                 1/1     Running   0          2m26s
        NAME                      TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
        service/webhook-service   ClusterIP   10.96.189.158   <none>        443/TCP   2m27s
        NAME                     DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR            AGE
        daemonset.apps/speaker   1         1         1       1            1           kubernetes.io/os=linux   17m
        NAME                         READY   UP-TO-DATE   AVAILABLE   AGE
        deployment.apps/controller   1/1     1            1           17m
        NAME                                    DESIRED   CURRENT   READY   AGE
        replicaset.apps/controller-5759df545c   0         0         0       17m
        replicaset.apps/controller-577b5bdfcc   1         1         1       2m27s
        replicaset.apps/controller-bdf98b979    0         0         0       9m29s
    Создаем манифест metallb-config.yaml и "kubectl apply -f metallb-config.yaml"
    Делаем копию файла web-svc-cip.yaml в web-svc-lb.yaml и ставим LoadBalancer "kubectl apply -f .\web-svc-lb.yaml"
    IP:                       10.106.146.215
    Затем пробуем зайти на веб интерфейс и не можем, находим адрес своего миникуба "minikube ssh" -> "ip addr show eth0"
        inet 192.168.49.2/24 brd 192.168.49.255 scope global eth0 
    Поигрался, в итоге не взлетело, бросил..
Создание Ingress
    "kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/baremetal/deploy.yaml"
    Создаем манифест nodeport.yaml и "kubectl apply -f .\nodeport.yaml"
Подключение приложение Web к Ingress
    Ккопируйкм web-svc-cip.yaml в web-svc-headless.yaml, меняем параметры и "kubectl apply -f .\web-svc-headless.yaml"
Создание правил Ingress
    Создаем манифест web-ingress.yaml и "kubectl apply -f .\web-ingress.yaml", 
    проверяем корректность заполнения "kubectl describe ingress/web"
